### PR TITLE
Fix TypeScript error in NextAuth signIn callback

### DIFF
--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -30,8 +30,8 @@ export const authOptions: NextAuthOptions = {
       }
       return session
     },
-    async signIn({ user, email }) {
-      console.log('Sign in attempt for:', user?.email || email?.verificationRequest?.identifier)
+    async signIn({ user }) {
+      console.log('Sign in attempt for:', user?.email)
       return true
     },
   },


### PR DESCRIPTION
## Summary
- Fix TypeScript build error in NextAuth signIn callback
- Remove incorrect access to email parameter properties  
- Resolve Vercel build failure

## Problem
The original authentication implementation had a TypeScript error:
Property 'identifier' does not exist on type 'boolean'

This was caused by incorrectly treating the email parameter in the signIn callback as an object when it's actually a boolean.

## Solution
- Updated the signIn callback to only access user?.email for debugging
- Removed the incorrect email?.verificationRequest?.identifier access
- Maintains all authentication functionality while fixing the type error

🤖 Generated with [Claude Code](https://claude.ai/code)